### PR TITLE
Fix collection class mapping

### DIFF
--- a/src/Controller/CollectionController.php
+++ b/src/Controller/CollectionController.php
@@ -51,7 +51,8 @@ class CollectionController extends AbstractController
         $repositoryProduct = $this->getDoctrine()->getRepository(Product::class);
         $products = $repositoryProduct->findAll();
         // TODO: Use getProducts() method to get them and not findBy Collection (don't forget view too)
-        dd($collections[0]);
+        // @Kevin, it works!
+        dd($collections[0]->getProducts()[0]);
 
         return $this->render('collection/collections.html.twig', [
             'collections' => $collections,

--- a/src/Entity/Collection.php
+++ b/src/Entity/Collection.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection as DoctrineCollection;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -101,9 +102,9 @@ class Collection
     }
 
     /**
-     * @return Collection|Product[]
+     * @return DoctrineCollection|Product[]
      */
-    public function getProducts(): Collection
+    public function getProducts(): DoctrineCollection
     {
         return $this->products;
     }


### PR DESCRIPTION
Le maker de Symfony a complètement planté lors de l'écriture/re-écriture des fichiers.

Cette PR corrige le problème. Si jamais tu as le même soucis sur d'autres entités (ProductCollection), tu peux appliquer la même modification.

À dispo, 

Pierre
